### PR TITLE
Docs: Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this lesson, please cite it as below."
+type: dataset
+title: "Data Management (and Sharing) Plans for Librarians 101"
+authors:
+  - family-names: Bohman
+    given-names: Lena
+  - family-names: Hertz
+    given-names: Marla
+  - family-names: Orlowska
+    given-names: Daria
+abstract: "Walks through providing data management plan services in your library. Covers DMPs, relevant resources, data interviews, using the DMPTool, and suggestions on implementing DMP services."
+keywords:
+  - data management
+  - sharing plans
+  - DMP
+  - DMPTool
+license: CC-BY-4.0
+version: 1.0.0
+date-released: 2025-12-23
+repository-code: "https://github.com/LibraryCarpentry/lc-dmp101"
+url: "https://librarycarpentry.org/lc-dmp101/"


### PR DESCRIPTION
This PR adds a CITATION.cff file to make the lesson citable, generated from the IMLS Open Science project metadata.